### PR TITLE
Fix: honeycomb CF template to allow multi-region config

### DIFF
--- a/packages/sam-config/templates/honeycomb-cloudwatch.yml
+++ b/packages/sam-config/templates/honeycomb-cloudwatch.yml
@@ -39,8 +39,14 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: honeycomb-builds
-        S3Key: honeycombio/integrations-for-aws/LATEST/ingest-handlers.zip
+        S3Bucket:
+          "Fn::Join":
+          - '-'
+          -
+            - honeycomb-integrations
+            - !Ref "AWS::Region"
+        S3Key: agentless-integrations-for-aws/LATEST/ingest-handlers.zip
+      Description: Lambda function for publishing asynchronous events from Lambda
       Environment:
         Variables:
           API_HOST: !Ref HoneycombAPIHost


### PR DESCRIPTION
For getting honeycomb log publisher Lambda function to work in regions other than us-east-1.

Reference: https://github.com/honeycombio/agentless-integrations-for-aws/commit/73dcf6df4fc1319afab0d2c3807b2166278f0cf5